### PR TITLE
Added getLogMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 ## Release notes
 
+### 1.2.0 (dev)
+
+* Added `LoggerSpy::getLogMessages`
+
 ### 1.1.0 (2016-11-11)
 
 * Added `LoggerSpy::assertNoLoggingCallsWhereMade`

--- a/src/LoggerSpy.php
+++ b/src/LoggerSpy.php
@@ -44,4 +44,17 @@ class LoggerSpy extends AbstractLogger {
 		}
 	}
 
+	/**
+	 * @since 1.2
+	 * @return string[]
+	 */
+	public function getLogMessages(): array {
+		return array_map(
+			function( array $logCall ) {
+				return $logCall['message'];
+			},
+			$this->logCalls
+		);
+	}
+
 }

--- a/tests/LoggerSpyTest.php
+++ b/tests/LoggerSpyTest.php
@@ -84,4 +84,27 @@ class LoggerSpyTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( true );
 	}
 
+	public function testWhenNothingIsLogged_getLogMessagesReturnsEmptyArray() {
+		$loggerSpy = new LoggerSpy();
+
+		$this->assertSame( [], $loggerSpy->getLogMessages() );
+	}
+
+	public function testWhenMultipleThingsAreLogged_getLogMessagesReturnsAllMessages() {
+		$loggerSpy = new LoggerSpy();
+
+		$loggerSpy->log( LogLevel::INFO, 'And so it begins' );
+		$loggerSpy->log( LogLevel::ALERT, "There's a hole in your mind" );
+		$loggerSpy->log( LogLevel::INFO, 'And so it begins' );
+
+		$this->assertSame(
+			[
+				'And so it begins',
+				"There's a hole in your mind",
+				'And so it begins'
+			],
+			$loggerSpy->getLogMessages()
+		);
+	}
+
 }


### PR DESCRIPTION
Often we're only interested in the log messages. This avoids
having to deal with the array structure

Allows killing assertCalledOnceWithMessage and LoggerSpy in the FunFun app