### PR TITLE
 	Use a value object and a collection for log call access

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 ## Release notes
 
-### 1.2.0 (dev)
+### 2.0.0 (dev)
 
-* Added `LoggerSpy::getLogMessages`
+* `LoggerSpy::getLogCalls` now returns an instance of `LogCalls`, which is a collection of `LogCall`
+* Added `LogCalls::getMessages`
+* Added `LogCalls::getFirstCall`
 
 ### 1.1.0 (2016-11-11)
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.1.x-dev"
+			"dev-master": "2.0.x-dev"
 		}
 	},
 	"scripts": {

--- a/src/LogCall.php
+++ b/src/LogCall.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\PsrLogTestDoubles;
+
+/**
+ * Value object representing a call to the logger
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LogCall {
+
+	private $level;
+	private $message;
+	private $context;
+
+	/**
+	 * @param mixed $level Typically one of the @see LogLevel constants
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function __construct( $level, string $message, array $context = [] ) {
+		$this->level = $level;
+		$this->message = $message;
+		$this->context = $context;
+	}
+
+	/**
+	 * @return mixed Typically one of the @see LogLevel constants
+	 */
+	public function getLevel() {
+		return $this->level;
+	}
+
+	public function getMessage(): string {
+		return $this->message;
+	}
+
+	public function getContext(): array {
+		return $this->context;
+	}
+
+}

--- a/src/LogCalls.php
+++ b/src/LogCalls.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\PsrLogTestDoubles;
+
+/**
+ * Immutable and ordered collection of LogCall objects
+ *
+ * @since 2.0
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LogCalls implements \IteratorAggregate {
+
+	private $calls;
+
+	/**
+	 * @param LogCall[] $calls
+	 */
+	public function __construct( LogCall... $calls ) {
+		$this->calls = $calls;
+	}
+
+	public function getIterator() {
+		return new \ArrayIterator( $this->calls );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getMessages(): array {
+		return array_map(
+			function( LogCall $logCall ) {
+				return $logCall->getMessage();
+			},
+			$this->calls
+		);
+	}
+
+	/**
+	 * @return LogCall|null
+	 */
+	public function getFirstCall() {
+		return empty( $this->calls ) ? null : $this->calls[0];
+	}
+
+}

--- a/src/LoggerSpy.php
+++ b/src/LoggerSpy.php
@@ -18,18 +18,14 @@ class LoggerSpy extends AbstractLogger {
 	 * @since 1.0
 	 */
 	public function log( $level, $message, array $context = [] ) {
-		$this->logCalls[] = [
-			'level' => $level,
-			'message' => $message,
-			'context' => $context
-		];
+		$this->logCalls[] = new LogCall( $level, $message, $context );
 	}
 
 	/**
-	 * @since 1.0
+	 * @since 2.0
 	 */
-	public function getLogCalls(): array {
-		return $this->logCalls;
+	public function getLogCalls(): LogCalls {
+		return new LogCalls( ...$this->logCalls );
 	}
 
 	/**
@@ -42,19 +38,6 @@ class LoggerSpy extends AbstractLogger {
 				'Logger calls where made while non where expected: ' . var_export( $this->logCalls, true )
 			);
 		}
-	}
-
-	/**
-	 * @since 1.2
-	 * @return string[]
-	 */
-	public function getLogMessages(): array {
-		return array_map(
-			function( array $logCall ) {
-				return $logCall['message'];
-			},
-			$this->logCalls
-		);
 	}
 
 }

--- a/tests/LogCallsTest.php
+++ b/tests/LogCallsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\PsrLogTestDoubles\Tests;
+
+use Psr\Log\LogLevel;
+use WMDE\PsrLogTestDoubles\LogCall;
+use WMDE\PsrLogTestDoubles\LogCalls;
+
+/**
+ * @covers \WMDE\PsrLogTestDoubles\LogCalls
+ *
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LogCallsTest extends \PHPUnit_Framework_TestCase {
+
+	public function testWhenThereAreNoLogCalls_getMessagesReturnsEmptyArray() {
+		$this->assertSame( [], ( new LogCalls() )->getMessages() );
+	}
+
+	public function testWhenMultipleThingsAreLogged_getLogMessagesReturnsAllMessages() {
+		$logCalls = new LogCalls(
+			new LogCall( LogLevel::INFO, 'And so it begins', [ 'year' => 2258 ] ),
+			new LogCall( LogLevel::ALERT, "There's a hole in your mind" ),
+			new LogCall( LogLevel::INFO, 'And so it begins' )
+		);
+
+		$this->assertSame(
+			[
+				'And so it begins',
+				"There's a hole in your mind",
+				'And so it begins'
+			],
+			$logCalls->getMessages()
+		);
+	}
+
+	public function testCanUseCollectionAsTraversable() {
+		$logCalls = new LogCalls( new LogCall( LogLevel::INFO, 'And so it begins' ) );
+
+		$this->assertContains( new LogCall( LogLevel::INFO, 'And so it begins' ), $logCalls, '', false, false );
+		$this->assertNotContains( new LogCall( LogLevel::DEBUG, 'And so it begins' ), $logCalls, '', false, false );
+	}
+
+	public function testWhenThereAreNoLogCalls_getFirstCallReturnsNull() {
+		$this->assertNull( ( new LogCalls() )->getFirstCall() );
+	}
+
+	public function testWhenMultipleThingsAreLogged_getFirstCallReturnsTheFirst() {
+		$logCalls = new LogCalls(
+			new LogCall( LogLevel::INFO, 'And so it begins', [ 'year' => 2258 ] ),
+			new LogCall( LogLevel::ALERT, "There's a hole in your mind" )
+		);
+
+		$this->assertSame( LogLevel::INFO, $logCalls->getFirstCall()->getLevel() );
+		$this->assertSame( 'And so it begins', $logCalls->getFirstCall()->getMessage() );
+		$this->assertSame( [ 'year' => 2258 ], $logCalls->getFirstCall()->getContext() );
+	}
+
+}

--- a/tests/LoggerSpyTest.php
+++ b/tests/LoggerSpyTest.php
@@ -6,6 +6,8 @@ namespace WMDE\PsrLogTestDoubles\Tests;
 
 use Psr\Log\LogLevel;
 use WMDE\PsrLogTestDoubles\AssertionException;
+use WMDE\PsrLogTestDoubles\LogCall;
+use WMDE\PsrLogTestDoubles\LogCalls;
 use WMDE\PsrLogTestDoubles\LoggerSpy;
 
 /**
@@ -19,7 +21,7 @@ class LoggerSpyTest extends \PHPUnit_Framework_TestCase {
 	public function testWhenNothingIsLogged_getLogCallsReturnsEmptyArray() {
 		$loggerSpy = new LoggerSpy();
 
-		$this->assertSame( [], $loggerSpy->getLogCalls() );
+		$this->assertEquals( new LogCalls(), $loggerSpy->getLogCalls() );
 	}
 
 	public function testWhenLogIsCalled_getLogCallsReturnsAllCalls() {
@@ -28,19 +30,11 @@ class LoggerSpyTest extends \PHPUnit_Framework_TestCase {
 		$loggerSpy->log( LogLevel::INFO, 'And so it begins', [ 'year' => 2258 ] );
 		$loggerSpy->log( LogLevel::ALERT, "There's a hole in your mind" );
 
-		$this->assertSame(
-			[
-				[
-					'level' => LogLevel::INFO,
-					'message' => 'And so it begins',
-					'context' => [ 'year' => 2258 ]
-				],
-				[
-					'level' => LogLevel::ALERT,
-					'message' => "There's a hole in your mind",
-					'context' => []
-				]
-			],
+		$this->assertEquals(
+			new LogCalls(
+				new LogCall( LogLevel::INFO, 'And so it begins', [ 'year' => 2258 ] ),
+				new LogCall( LogLevel::ALERT, "There's a hole in your mind" )
+			),
 			$loggerSpy->getLogCalls()
 		);
 	}
@@ -51,19 +45,11 @@ class LoggerSpyTest extends \PHPUnit_Framework_TestCase {
 		$loggerSpy->info( 'And so it begins', [ 'year' => 2258 ] );
 		$loggerSpy->alert( "There's a hole in your mind" );
 
-		$this->assertSame(
-			[
-				[
-					'level' => LogLevel::INFO,
-					'message' => 'And so it begins',
-					'context' => [ 'year' => 2258 ]
-				],
-				[
-					'level' => LogLevel::ALERT,
-					'message' => "There's a hole in your mind",
-					'context' => []
-				]
-			],
+		$this->assertEquals(
+			new LogCalls(
+				new LogCall( LogLevel::INFO, 'And so it begins', [ 'year' => 2258 ] ),
+				new LogCall( LogLevel::ALERT, "There's a hole in your mind" )
+			),
 			$loggerSpy->getLogCalls()
 		);
 	}
@@ -82,29 +68,6 @@ class LoggerSpyTest extends \PHPUnit_Framework_TestCase {
 		$loggerSpy->assertNoLoggingCallsWhereMade();
 
 		$this->assertTrue( true );
-	}
-
-	public function testWhenNothingIsLogged_getLogMessagesReturnsEmptyArray() {
-		$loggerSpy = new LoggerSpy();
-
-		$this->assertSame( [], $loggerSpy->getLogMessages() );
-	}
-
-	public function testWhenMultipleThingsAreLogged_getLogMessagesReturnsAllMessages() {
-		$loggerSpy = new LoggerSpy();
-
-		$loggerSpy->log( LogLevel::INFO, 'And so it begins' );
-		$loggerSpy->log( LogLevel::ALERT, "There's a hole in your mind" );
-		$loggerSpy->log( LogLevel::INFO, 'And so it begins' );
-
-		$this->assertSame(
-			[
-				'And so it begins',
-				"There's a hole in your mind",
-				'And so it begins'
-			],
-			$loggerSpy->getLogMessages()
-		);
 	}
 
 }


### PR DESCRIPTION
This avoids having to pass around arrays with special keys.

It also allows for adding filtering behaviour, ie

```php
$logCalls->getWithLevel( LogLevel::ERROR )->getMessages()
```

What do you think of this approach?