### PR TITLE
Fix PHP 8.1 incompatibility errors

### DIFF
--- a/src/LogCalls.php
+++ b/src/LogCalls.php
@@ -23,6 +23,7 @@ class LogCalls implements \IteratorAggregate, \Countable {
 		$this->calls = $calls;
 	}
 
+    #[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new \ArrayIterator( $this->calls );
 	}
@@ -43,6 +44,7 @@ class LogCalls implements \IteratorAggregate, \Countable {
 		return empty( $this->calls ) ? null : $this->calls[0];
 	}
 
+    #[\ReturnTypeWillChange]
 	/**
 	 * @since 2.1
 	 * @return int

--- a/src/LogCalls.php
+++ b/src/LogCalls.php
@@ -23,7 +23,7 @@ class LogCalls implements \IteratorAggregate, \Countable {
 		$this->calls = $calls;
 	}
 
-    #[\ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new \ArrayIterator( $this->calls );
 	}
@@ -44,7 +44,7 @@ class LogCalls implements \IteratorAggregate, \Countable {
 		return empty( $this->calls ) ? null : $this->calls[0];
 	}
 
-    #[\ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	/**
 	 * @since 2.1
 	 * @return int


### PR DESCRIPTION
In PHP 8.1 a new deprecation error is triggered because the `getIterator()` and `getCount()` methods don't conform to the built in `Traversable` and `Countable` interfaces.

For example: ```PHP Deprecated:  Return type of WMDE\PsrLogTestDoubles\LogCalls::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice``` and ```PHP Deprecated:  Return type of WMDE\PsrLogTestDoubles\LogCalls::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice```

The 2 ways to fix this is either add an attribute is either to add the return typehint or to add the attribute. Since on PHP 7.1 these methods didn't have a return typehint, and covariance/contravariance is only fully supported in 7.4, adding the attribute should be more backwards compatible because they will just be treated as comments versions before 8.0.