### PR TITLE
[phpstan update fix] Update actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           tools: composer, cs2pr
           coverage: pcov
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: composer-cache-php${{ matrix.php }}
@@ -71,10 +71,10 @@ jobs:
           extensions: mbstring
           tools: composer, cs2pr
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: "composer-cache-php${{ matrix.php }}"


### PR DESCRIPTION
- version 2 was deprecated in Feb2025 (see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)
- this is a fix for https://github.com/wmde/PsrLogTestDoubles/pull/22